### PR TITLE
refactor: remove unused resource_group parameter from get_post method

### DIFF
--- a/src/spaceone/board/service/post_service.py
+++ b/src/spaceone/board/service/post_service.py
@@ -321,7 +321,6 @@ class PostService(BaseService):
         post_id = params["post_id"]
         domain_id = params.get("domain_id")
         workspace_id = params.get("workspace_id")
-        resource_group = params.get("resource_group")
 
         post_vo = self.post_mgr.get_post(post_id, domain_id, workspace_id)
         self.post_mgr.increase_view_count(post_vo)


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [x] Refactor
- [ ] etc

### Description
refactor: remove unused resource_group parameter from get_post method
### Known issue
